### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Get the timestamp of creation of the ID can be extracted by using this method. T
 ...
 
 // Pass the custom epoch that was used to generate this ID
-const ts = Snowflake.timestampFromId(id, uid.customEpoch());
+const ts = Snowflake.timestampFromID(id, uid.customEpoch());
 
 console.log(ts) // Timestamp of creation of the id
 


### PR DESCRIPTION
From `timestampFromId` to `timestampFromID`

I tried to use SnowFlake.timestampFromId according to the README and it did not work. After rechecking the function name in `src/lib.rs`, the correct function is `timestampFromID`.